### PR TITLE
Remove member and clear

### DIFF
--- a/src/go_dutch/group.py
+++ b/src/go_dutch/group.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 # Group class
 class Group():
 
@@ -61,3 +59,16 @@ class Group():
 
     def get_balances (self) -> dict:
         return self.__balances
+
+    # remove a single member from the group only if the member is settled
+    def remove_settled_member (self, member: str) -> None:
+        if member not in self.__balances:
+            raise KeyError(f"{member} is not part of group {self}")
+        if self.__balances[member] != 0:
+            raise ValueError(f"{member} is not settled")
+        del self.__balances[member]
+
+    # clears all information from group
+    def clear (self) -> None:
+        self.__balances.clear()
+        self.__ledger.clear()

--- a/tests/test.py
+++ b/tests/test.py
@@ -82,3 +82,26 @@ def test_has_member():
     group = Group(['joe'])
     assert group.has_member('joe')
     assert not group.has_member("john")
+
+def test_remove_settled_member():
+    member1, member2 = "Arthur", "Sadie"
+    group1 = Group([member1])
+
+    # non-existent member
+    with pytest.raises(KeyError):
+        group1.remove_settled_member(member2)
+
+    # successful removal of settled member
+    group1.remove_settled_member(member1)
+    assert group1.get_balances().__len__() == 0
+
+    # TODO: member yet to settle
+    # with pytest.raises(ValueError):
+        # group1.remove_settled_member(<>)
+
+def test_clear():
+    member1, member2 = "Micah", "Javier"
+    group1 = Group([member1, member2])
+    group1.clear()
+    assert group1.get_balances().__len__() == 0
+    assert not group1.get_ledger()


### PR DESCRIPTION
Testing for remove_settled_member currently lacks checking for member who is not settled. Balances are private, so we can't have a member's balance other than zero. The corresponding test case is commented out as a TODO.

Also, I added a clear function as well which came to my mind during the task.